### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Get band requests, ban, unban, timeout
 
 (only users in the admin white list)
 ```code
-!ban username //bans username from the cannel
+!ban username //bans username from the channel
 !timeout username //bans username during 600 (by default) seconds 
 !timeout username 60 //bans username during 60 seconds
 


### PR DESCRIPTION
## Summary
- fix typo `cannel` -> `channel` in README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6847b56120e4832bb6f23e2c167f393a